### PR TITLE
feat: containerised ingestion with parallel uploads

### DIFF
--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -1,0 +1,18 @@
+
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+COPY pyproject.toml uv.lock ./
+
+RUN uv sync --frozen --no-dev
+
+COPY ingestion/scripts/load_to_gcs.py ./ingestion/scripts/
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+
+CMD ["python", "ingestion/scripts/load_to_gcs.py"]

--- a/ingestion/scripts/load_to_gcs.py
+++ b/ingestion/scripts/load_to_gcs.py
@@ -1,14 +1,15 @@
+
 """
 Ingestion Script: Local CSV files -> Google Cloud Storage
 
 This script:
 1. Reads raw CSV files from data/raw/
 2. Validates each file exists and is readable
-3. Uploads to GCS bucket maintaining folder structure
+3. Uploads to GCS bucket in parallel (max 3 concurrent uploads)
 4. Logs progress and any errors
 
 Usage:
-    uv run python ingestion/scripts/load_to_gcs.py
+    python ingestion/scripts/load_to_gcs.py
 """
 
 import os
@@ -16,6 +17,7 @@ import logging
 from pathlib import Path
 from dotenv import load_dotenv
 from google.cloud import storage
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 # -- Configuration -----------------------------------------------------
 load_dotenv()
@@ -24,6 +26,7 @@ GCP_PROJECT_ID = os.getenv("GCP_PROJECT_ID")
 GCS_BUCKET_NAME = os.getenv("GCS_BUCKET_NAME")
 RAW_DATA_PATH = Path("data/raw")
 GCS_DESTINATION_PREFIX = "home-credit/raw"
+MAX_WORKERS = 3  # safe limit for GCS API rate limits
 
 # -- Logging -----------------------------------------------------------
 logging.basicConfig(
@@ -67,9 +70,9 @@ def upload_file_to_gcs(
     local_path: Path,
     bucket_name: str,
     destination_prefix: str,
-) -> bool:
+) -> tuple[str, bool, str]:
     """
-    Upload a single file to GCS.
+    Upload a single file to GCS with resumable upload for large files.
 
     Args:
         client: Authenticated GCS client
@@ -78,60 +81,81 @@ def upload_file_to_gcs(
         destination_prefix: Folder prefix in GCS
 
     Returns:
-        True if successful, False otherwise
+        Tuple of (filename, success, error_message)
     """
     try:
         bucket = client.bucket(bucket_name)
         destination_blob = f"{destination_prefix}/{local_path.name}"
         blob = bucket.blob(destination_blob)
 
-        logger.info(f"Uploading {local_path.name} -> gs://{bucket_name}/{destination_blob}")
-
-        blob.upload_from_filename(
-            str(local_path),
-            timeout=300
-        )
-
         file_size_mb = local_path.stat().st_size / (1024 * 1024)
+        logger.info(f"Uploading {local_path.name} ({file_size_mb:.1f} MB) -> gs://{bucket_name}/{destination_blob}")
+
+        # Use resumable upload for files over 100MB for reliability
+        if file_size_mb > 100:
+            with open(local_path, "rb") as f:
+                blob.upload_from_file(
+                    f,
+                    timeout=600,      # 10 minute timeout for large files
+                    checksum="md5",   # verify integrity after upload
+                )
+        else:
+            blob.upload_from_filename(
+                str(local_path),
+                timeout=300,
+            )
+
         logger.info(f"Uploaded {local_path.name} ({file_size_mb:.1f} MB)")
-        return True
+        return (local_path.name, True, "")
 
     except Exception as e:
         logger.error(f"Failed to upload {local_path.name}: {e}")
-        return False
+        return (local_path.name, False, str(e))
 
 
 def main() -> None:
-    """Main ingestion pipeline -- CSV files to GCS."""
+    """Main ingestion pipeline with parallel uploads."""
     logger.info("Starting ingestion pipeline: Local CSV -> GCS")
     logger.info(f"Source: {RAW_DATA_PATH}")
     logger.info(f"Destination: gs://{GCS_BUCKET_NAME}/{GCS_DESTINATION_PREFIX}")
+    logger.info(f"Parallel workers: {MAX_WORKERS}")
 
     validate_environment()
     client = get_gcs_client()
 
     results = {"success": [], "failed": [], "missing": []}
 
+    # Separate existing files from missing ones
+    files_to_upload = []
     for filename in TARGET_FILES:
         local_path = RAW_DATA_PATH / filename
-
         if not local_path.exists():
             logger.warning(f"File not found, skipping: {filename}")
             results["missing"].append(filename)
-            continue
-
-        success = upload_file_to_gcs(
-            client=client,
-            local_path=local_path,
-            bucket_name=GCS_BUCKET_NAME,
-            destination_prefix=GCS_DESTINATION_PREFIX,
-        )
-
-        if success:
-            results["success"].append(filename)
         else:
-            results["failed"].append(filename)
+            files_to_upload.append(local_path)
 
+    # Upload in parallel with bounded thread pool
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        futures = {
+            executor.submit(
+                upload_file_to_gcs,
+                client,
+                local_path,
+                GCS_BUCKET_NAME,
+                GCS_DESTINATION_PREFIX,
+            ): local_path.name
+            for local_path in files_to_upload
+        }
+
+        for future in as_completed(futures):
+            filename, success, error = future.result()
+            if success:
+                results["success"].append(filename)
+            else:
+                results["failed"].append((filename, error))
+
+    # Summary
     logger.info("=" * 50)
     logger.info("INGESTION SUMMARY")
     logger.info(f"Successful: {len(results['success'])} files")
@@ -139,7 +163,8 @@ def main() -> None:
     logger.info(f"Missing:    {len(results['missing'])} files")
 
     if results["failed"]:
-        logger.error(f"Failed files: {results['failed']}")
+        for filename, error in results["failed"]:
+            logger.error(f"  {filename}: {error}")
         raise RuntimeError("Some files failed to upload")
 
     logger.info("Ingestion pipeline complete")


### PR DESCRIPTION
Dockerfile:
- Python 3.12-slim base image
- uv installed via multi-stage copy from official image
- Dependencies installed at build time via uv sync --frozen --no-dev
- PATH set to /app/.venv/bin — no uv run at runtime, no dev dependencies
- PYTHONUNBUFFERED and PYTHONDONTWRITEBYTECODE configured
- CMD calls Python directly from venv for clean signal handling

load_to_gcs.py:
- Parallel uploads using ThreadPoolExecutor with MAX_WORKERS=3
- Bounded concurrency — safe for GCS API rate limits
- Resumable upload with MD5 checksum for files over 100MB
- Standard upload for files under 100MB
- Returns tuple (filename, success, error) per thread
- as_completed() processes results as each upload finishes
- Detailed summary with per-file error reporting on failure

## Summary
Containerised ingestion pipeline with parallel uploads. Docker image 
runs cleanly with no dev dependencies at runtime. All 9 raw Home Credit 
CSV files (2.5GB) uploaded to GCS successfully in parallel batches of 3.

## Ticket
Closes #002

## Type of Change
- [x] New feature

## dbt Changes
- N/A

## Checklist
- [x] No hardcoded values — all config via environment variables
- [x] Tested end to end — 9 files, 0 failed, 0 missing
- [x] Branch is up to date with main

## How to Test
1. Copy .env.example to .env and fill in credentials
2. docker build -t home-credit-ingestion -f ingestion/Dockerfile .
3. docker run with env and volume mounts
4. Verify summary shows 9 successful, 0 failed

## Screenshots / Query Results
Successful: 9 files
Failed:     0 files
Missing:    0 files
Total data: ~2.5GB uploaded in parallel batches of 3